### PR TITLE
New PR for admin-dashboard-init

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -8,6 +8,7 @@
     <title><%= htmlWebpackPlugin.options.title %></title>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400,500,700,900">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@mdi/font@latest/css/materialdesignicons.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Material+Icons" rel="stylesheet">
   </head>
   <body>
     <noscript>

--- a/src/plugins/vuetify.js
+++ b/src/plugins/vuetify.js
@@ -1,9 +1,5 @@
-/* eslint-disable import/no-extraneous-dependencies */
-// https://vuetifyjs.com/en/features/icon-fonts/#material-icons: follow instructions to download material icon package
-
 import Vue from 'vue';
 import Vuetify from 'vuetify/lib/framework';
-import 'material-design-icons-iconfont/dist/material-design-icons.css';
 
 Vue.use(Vuetify);
 


### PR DESCRIPTION
- No longer need to install material icons with npm 