### PR TITLE
Icon Colors Updated from Navy to Black

### DIFF
--- a/src/components/Admin/AdminDashboard.vue
+++ b/src/components/Admin/AdminDashboard.vue
@@ -65,7 +65,7 @@
             <v-icon
               size="320"
               style="padding: 45px 0;
-                color: #00264D;
+                color: black;
                 text-align: center;"
             >schedule</v-icon>
           </span>
@@ -141,7 +141,7 @@
             <v-icon
               size="320"
               style="padding: 45px 0;
-                color: #00264D;
+                color: black;
                 text-align: center;"
             >plagiarism</v-icon>
           </span>
@@ -220,7 +220,7 @@
             <v-icon
               size="320"
               style="padding: 45px 0;
-                color: #00264D;
+                color: black;
                 text-align: center;"
             >group</v-icon>
           </span>
@@ -297,7 +297,7 @@
             <v-icon
               size="320"
               style="padding: 45px 0;
-                color: #00264D;"
+                color: black;"
             >help</v-icon>
           </span>
           <v-expand-transition>

--- a/src/components/Admin/AllDevices.vue
+++ b/src/components/Admin/AllDevices.vue
@@ -31,7 +31,7 @@
           <v-icon
             size="50"
             style="padding: 0;
-                color: #00264D;"
+                color: black;"
           >
             home
           </v-icon>


### PR DESCRIPTION
I updated the admin colors from navy to black for the following: 
Admin Dashboard -- changed AdminDashboard.vue
All Devices -- changed AllDevices.vue 

In both of these components, simple changes of replacing the navy color value ("#00264D") with "black" were made.

Please note that ModifyInventory.vue was not updated because the functionality from this file will be implemented in AllDevices in the future, making it pointless to update the design of a page that will soon be deleted.