### PR TITLE
Add FB functionality to UserHome, Created new FB function

### DIFF
--- a/src/components/User/UserHome.vue
+++ b/src/components/User/UserHome.vue
@@ -1,75 +1,95 @@
 <template>
-  <v-container>
-    <v-btn
-      color="#E0E0E0"
-      class="mb-8"
-      href="/#/UserRes"
-      block
-      large
-    >
-      My Reservations
-    </v-btn>
+  <v-container
+    fluid
+  >
     <v-card>
-      <v-toolbar
-        color="black"
-        dark
+      <v-card-title>
+        <v-spacer />
+      </v-card-title>
+      <v-data-table
+        :headers="headers"
+        :items="devices"
+        :search="search"
+        class="elevation-1"
       >
-        <v-toolbar-title>Available Reservations</v-toolbar-title>
-      </v-toolbar>
-      <v-expansion-panels focusable>
-        <v-expansion-panel>
-          <v-expansion-panel-header>
-            Apple MacBook Air
-          </v-expansion-panel-header>
-          <v-expansion-panel-content
-            class="mt-4 mx-auto"
+        <template v-slot:top>
+          <v-toolbar
+            flat
           >
-            <v-row>
-              This can be checked out for a maximum of 7 days.
-            </v-row>
-            <v-row>
-              <v-btn
-                href="/#/UserReviewRes"
-                class="mt-2 mb-2"
-              >
-                Reserve
-              </v-btn>
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-        <v-expansion-panel>
-          <v-expansion-panel-header>
-            Lenovo Mouse
-          </v-expansion-panel-header>
-          <v-expansion-panel-content
-            class="mt-4 mx-auto"
+            <v-text-field
+              v-model="search"
+              append-icon="mdi-magnify"
+              label="Search"
+              color="#600000"
+              single-line
+              hide-details
+              class="pr-16"
+              width="800px"
+            />
+            <v-spacer />
+          </v-toolbar>
+        </template>
+        <template v-slot:[`item.actions`]="{ item }">
+          <v-btn
+            href="/#/UserReviewRes"
+            @click="selectItem(item)"
           >
-            <v-row>
-              This can be checked out for a maximum of 5 hours.
-            </v-row>
-            <v-row>
-              <v-btn
-                href="/#/UserReviewRes"
-                class="mt-2 mb-2"
-              >
-                Reserve
-              </v-btn>
-            </v-row>
-          </v-expansion-panel-content>
-        </v-expansion-panel>
-      </v-expansion-panels>
+            Reserve
+          </v-btn>
+        </template>
+      </v-data-table>
     </v-card>
   </v-container>
 </template>
 
 <script>
+import { getAvailableReservations } from '../../firebase/techCenterCheckout.Data';
 import bannerStore from '../../store';
 
 export default {
   name: 'UserHome',
+  data: () => ({
+    search: '',
+    headers: [
+      {
+        text: 'Device Name',
+        align: 'start',
+        filterable: true,
+        value: 'deviceName',
+      },
+      { text: 'Minimum Duration', value: 'minimumDuration' },
+      { text: 'Maximum Duration', value: 'maximumDuration' },
+      { text: 'Actions', value: 'actions', filterable: false },
+    ],
+    devices: [],
+    selctedIndex: -1,
+    selectedItem: {
+      deviceName: '',
+      deviceTag: -1,
+      minimumDuration: '',
+      maximumDuration: '',
+      status: '',
+    },
+  }),
+
   created() {
-    bannerStore.setTitle('User Home');
+    bannerStore.setTitle('Available Reservations');
+    this.getAvailableResFromFB();
+  },
+  methods: {
+    async getAvailableResFromFB() {
+      try {
+        const inventory = await getAvailableReservations();
+        this.devices = inventory;
+      } catch (e) {
+        console.log(e);
+      }
+    },
+    selectItem(item) {
+      this.selctedIndex = this.devices.indexOf(item);
+      this.selectedItem = { ...item };
+      console.log(this.selectedItem.deviceName);
+    },
   },
 };
-
 </script>

--- a/src/components/User/UserHome.vue
+++ b/src/components/User/UserHome.vue
@@ -87,7 +87,7 @@ export default {
     selectItem(item) {
       this.selctedIndex = this.devices.indexOf(item);
       this.selectedItem = { ...item };
-      console.log(this.selectedItem.deviceName);
+      
     },
   },
 };

--- a/src/components/User/UserHome.vue
+++ b/src/components/User/UserHome.vue
@@ -68,7 +68,6 @@ export default {
       deviceTag: -1,
       minimumDuration: '',
       maximumDuration: '',
-      status: '',
     },
   }),
 

--- a/src/components/User/UserReviewRes.vue
+++ b/src/components/User/UserReviewRes.vue
@@ -2,10 +2,11 @@
   <v-container>
     <v-card>
       <v-toolbar
-        color="black"
-        dark
+        class="elevation-0"
       >
-        <v-toolbar-title>Apple MacBook Air</v-toolbar-title>
+        <v-toolbar-title>
+          Apple MacBook Air
+        </v-toolbar-title>
       </v-toolbar>
       <v-menu
         v-model="menu2"
@@ -57,6 +58,7 @@ export default {
   name: 'UserReviewRes',
   data: () => ({
     menu2: false,
+    props: { selectedDevice: Number },
     items: ['Foo', 'Bar', 'Fizz', 'Buzz'],
     date: new Date(Date.now()).toISOString().substr(0, 10),
   }),

--- a/src/firebase/techCenterCheckout.Data.js
+++ b/src/firebase/techCenterCheckout.Data.js
@@ -19,6 +19,21 @@ async function getCollection() {
   return allDevices;
 }
 
+async function getAvailableReservations() {
+  const querySnapshot = await getDocs(collection(db, 'All Devices'));
+  const allDevices = [];
+  querySnapshot.forEach((doc) => {
+    const data = {
+      deviceName: doc.data().deviceName,
+      deviceTag: doc.data().deviceTag,
+      minimumDuration: doc.data().minimumDuration,
+      maximumDuration: doc.data().maximumDuration,
+    };
+    allDevices.push(data);
+  });
+  return allDevices;
+}
+
 // Read all current reservations for a user
 // Parameter - username
 async function retrieveUserCurrentRes(username) {
@@ -144,6 +159,7 @@ function getTimeAvailability() {
 
 export {
   getCollection,
+  getAvailableReservations,
   retrieveUserCurrentRes,
   retrieveUserCheckedOutItems,
   retrieveUserUpcomingReservations,


### PR DESCRIPTION
For this pull request, I added FB functionality to the UserHome page, which is now in a datatable format compared to the expansion panels. I decided to create a new function that requested deviceName, deviceTag, and min and max duration that can be displayed for the user. I have a plan that once the user clicks the reserve button, then it will grab the deviceTag and query the availability in the review reservation page. I created a function to make sure that once the button is clicked, it will log in the console the right item. I also made minor changes to the ReviewRes component, but it is only design and not functionality.